### PR TITLE
Do not compress videos

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java
@@ -589,6 +589,7 @@ public class SendMessagesHelper extends BaseController implements NotificationCe
         public boolean forceImage;
         public boolean updateStickersOrder;
         public boolean hasMediaSpoilers;
+        public boolean doNotCompress;
         public TLRPC.VideoSize emojiMarkup;
     }
 
@@ -7982,7 +7983,7 @@ public class SendMessagesHelper extends BaseController implements NotificationCe
                             videoEditedInfo = info.videoEditedInfo != null ? info.videoEditedInfo : createCompressionSettings(info.path);
                         }
 
-                        if (!forceDocument && (videoEditedInfo != null || info.path.endsWith("mp4"))) {
+                        if (info.doNotCompress || (!forceDocument && (videoEditedInfo != null || info.path.endsWith("mp4")))) {
                             if (info.path == null && info.searchImage != null) {
                                 if (info.searchImage.photo instanceof TLRPC.TL_photo) {
                                     info.path = FileLoader.getInstance(accountInstance.getCurrentAccount()).getPathToAttach(info.searchImage.photo, true).getAbsolutePath();
@@ -8036,6 +8037,9 @@ public class SendMessagesHelper extends BaseController implements NotificationCe
                                     }
                                 }
                                 document = new TLRPC.TL_document();
+                                TLRPC.TL_documentAttributeFilename fileName = new TLRPC.TL_documentAttributeFilename();
+                                fileName.file_name = new File(path).getName();
+                                document.attributes.add(fileName);
                                 document.file_reference = new byte[0];
                                 if (size != null) {
                                     document.thumbs.add(size);
@@ -8714,6 +8718,9 @@ public class SendMessagesHelper extends BaseController implements NotificationCe
                         document.thumbs.add(size);
                         document.flags |= 1;
                     }
+                    TLRPC.TL_documentAttributeFilename fileName = new TLRPC.TL_documentAttributeFilename();
+                    fileName.file_name = new File(path).getName();
+                    document.attributes.add(fileName);
                     document.file_reference = new byte[0];
                     document.mime_type = "video/mp4";
                     accountInstance.getUserConfig().saveConfig(false);

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -11233,7 +11233,7 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
     @Override
     public void didSelectPhotos(ArrayList<SendMessagesHelper.SendingMediaInfo> photos, boolean notify, int scheduleDate) {
         fillEditingMediaWithCaption(photos.get(0).caption, photos.get(0).entities);
-        SendMessagesHelper.prepareSendingMedia(getAccountInstance(), photos, dialog_id, replyingMessageObject, getThreadMessage(), null, replyingQuote, true, false, editingMessageObject, notify, scheduleDate, photos.get(0).updateStickersOrder, null);
+        SendMessagesHelper.prepareSendingMedia(getAccountInstance(), photos, dialog_id, replyingMessageObject, getThreadMessage(), null, replyingQuote, true, true, editingMessageObject, notify, scheduleDate, photos.get(0).updateStickersOrder, null);
         afterMessageSend();
         if (scheduleDate != 0) {
             if (scheduledMessagesCount == -1) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertDocumentLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertDocumentLayout.java
@@ -890,6 +890,7 @@ public class ChatAttachAlertDocumentLayout extends ChatAttachAlert.AttachAlertLa
                 info.thumbPath = photoEntry.thumbPath;
                 info.videoEditedInfo = photoEntry.editedInfo;
                 info.isVideo = photoEntry.isVideo;
+                info.doNotCompress = info.isVideo;
                 info.caption = photoEntry.caption != null ? photoEntry.caption.toString() : null;
                 info.entities = photoEntry.entities;
                 info.masks = photoEntry.stickers;


### PR DESCRIPTION
When you're sending an video from android, it's not possible to send it without modifying video file. It will be remuxed (taking video stream into a new container, losing all it's metadata in the best case), even if you select the highest quality, if it has big enough bitrate, it will be forcefully compressed. It can't be disabled. Also it does compress audio horribly, with artifacts at the beginning. 
These both action are very slow, it's much faster to send a video as document, which results that video is send exactly as is, without any changes (the same file hash). But it results to video is not embedded in chat, it does show as a document, not as video. Telegram Desktop and Telegram Web does not modify video file in any way, but video does show as a video.
My patch resolves this problem. Now you can send a video as document, but it will show as video anyway. Click file - gallery and select a video. The same behavior as is in official Telegram X client. 
It also fixes the problem with missing video file name.