### PR TITLE
fix invalid path to AndroidManifest*.xml files in TMessagesProj_App/build.gradle

### DIFF
--- a/TMessagesProj_App/build.gradle
+++ b/TMessagesProj_App/build.gradle
@@ -49,7 +49,7 @@ android {
 
     def fdroid = Utils['isFdroid']()
     def appSuffix = fdroid ? "" : ".beta"
-    def flavorsConfig = fdroid ? "config/release" : "config/debug"
+    def flavorsConfig = fdroid ? "release" : "debug"
     if (fdroid) {
         defaultConfig.applicationId = "org.forkgram.messenger"
     }


### PR DESCRIPTION
I found that using `flavorsConfig` results in duplicate "config/" in paths, making them unreachable. This causes parts of AndroidManifest.xml to be missing in some builds. I believe this should fix #282, fix #218, fix #144, and fix #99.