### PR TITLE
Update UnifiedPush and switch to PushService

### DIFF
--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -7,12 +7,6 @@ apply plugin: 'kotlin-android'
 repositories {
     mavenCentral()
     google()
-    maven {
-        url 'https://www.jitpack.io'
-        content {
-            includeModule 'com.github.UnifiedPush', 'android-connector'
-        }
-    }
 }
 
 configurations {
@@ -63,7 +57,7 @@ dependencies {
             because("kotlin-stdlib-jdk8 is now a part of kotlin-stdlib")
         }
     }
-    implementation 'com.github.UnifiedPush:android-connector:2.3.1'
+    implementation 'org.unifiedpush.android:connector:3.1.2'
     implementation 'org.osmdroid:osmdroid-android:6.1.20'
 }
 

--- a/TMessagesProj/src/main/AndroidManifest.xml
+++ b/TMessagesProj/src/main/AndroidManifest.xml
@@ -638,15 +638,12 @@ e            <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
             </intent-filter>
         </receiver>
-        
-        <receiver android:exported="true" android:enabled="true" android:name="org.telegram.messenger.UnifiedPushReceiver">
+
+        <service android:exported="false" android:name="org.telegram.messenger.UnifiedPushService">
             <intent-filter>
-                <action android:name="org.unifiedpush.android.connector.MESSAGE"/>
-                <action android:name="org.unifiedpush.android.connector.UNREGISTERED"/>
-                <action android:name="org.unifiedpush.android.connector.NEW_ENDPOINT"/>
-                <action android:name="org.unifiedpush.android.connector.REGISTRATION_FAILED"/>
+                <action android:name="org.unifiedpush.android.connector.PUSH_EVENT"/>
             </intent-filter>
-        </receiver>
+        </service>
 
         <service
             android:name=".ContactsWidgetService"

--- a/TMessagesProj/src/main/java/org/telegram/messenger/PushListenerController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/PushListenerController.java
@@ -1696,13 +1696,13 @@ public class PushListenerController {
     }
     public final static class UnifiedPushListenerServiceProvider implements IPushListenerServiceProvider {
         public final static UnifiedPushListenerServiceProvider INSTANCE = new UnifiedPushListenerServiceProvider();
-        private final static UnifiedPushReceiver mReceiver = new UnifiedPushReceiver();
+        private final static UnifiedPushService mService = new UnifiedPushService();
 
         private UnifiedPushListenerServiceProvider(){};
 
         @Override
         public boolean hasServices() {
-            return !UnifiedPush.getDistributors(ApplicationLoader.applicationContext, new ArrayList()).isEmpty();
+            return !UnifiedPush.getDistributors(ApplicationLoader.applicationContext).isEmpty();
         }
 
         @Override
@@ -1730,18 +1730,17 @@ public class PushListenerController {
                         SharedConfig.pushStringGetTimeStart = SystemClock.elapsedRealtime();
                         SharedConfig.saveConfig();
                         if (UnifiedPush.getAckDistributor(ApplicationLoader.applicationContext) == null) {
-                            List<String> distributors = UnifiedPush.getDistributors(ApplicationLoader.applicationContext, new ArrayList<>());
+                            List<String> distributors = UnifiedPush.getDistributors(ApplicationLoader.applicationContext);
                             if (distributors.size() > 0) {
                                 String distributor = distributors.get(0);
                                 UnifiedPush.saveDistributor(ApplicationLoader.applicationContext, distributor);
                             }
                         }
-                        UnifiedPush.registerApp(
+                        UnifiedPush.register(
                                 ApplicationLoader.applicationContext,
                                 "default",
-                                new ArrayList<>(),
-                                "Telegram Simple Push"
-                        );
+                                "Telegram Simple Push",
+                                null);
                     } catch (Throwable e) {
                         FileLog.e(e);
                     }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/UnifiedPushService.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/UnifiedPushService.java
@@ -4,14 +4,17 @@ import android.content.Context;
 import android.os.SystemClock;
 
 import org.telegram.tgnet.ConnectionsManager;
-import org.unifiedpush.android.connector.MessagingReceiver;
+import org.unifiedpush.android.connector.FailedReason;
+import org.unifiedpush.android.connector.PushService;
 import org.unifiedpush.android.connector.UnifiedPush;
+import org.unifiedpush.android.connector.data.PushEndpoint;
+import org.unifiedpush.android.connector.data.PushMessage;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.concurrent.CountDownLatch;
 
-public class UnifiedPushReceiver extends MessagingReceiver {
+public class UnifiedPushService extends PushService {
 
     private static long lastReceivedNotification = 0;
     private static long numOfReceivedNotifications = 0;
@@ -25,17 +28,17 @@ public class UnifiedPushReceiver extends MessagingReceiver {
     }
 
     @Override
-    public void onNewEndpoint(Context context, String endpoint, String instance){
+    public void onNewEndpoint(PushEndpoint endpoint, String instance){
         Utilities.globalQueue.postRunnable(() -> {
             SharedConfig.pushStringGetTimeEnd = SystemClock.elapsedRealtime();
 
-            String savedDistributor = UnifiedPush.getSavedDistributor(context);
+            String savedDistributor = UnifiedPush.getSavedDistributor(this);
 
             if (savedDistributor.equals("io.heckel.ntfy")) {
-                PushListenerController.sendRegistrationToServer(PushListenerController.PUSH_TYPE_SIMPLE, endpoint);
+                PushListenerController.sendRegistrationToServer(PushListenerController.PUSH_TYPE_SIMPLE, endpoint.getUrl());
             } else {
                 try {
-                    PushListenerController.sendRegistrationToServer(PushListenerController.PUSH_TYPE_SIMPLE, SharedConfig.unifiedPushGateway + URLEncoder.encode(endpoint, "UTF-8"));
+                    PushListenerController.sendRegistrationToServer(PushListenerController.PUSH_TYPE_SIMPLE, SharedConfig.unifiedPushGateway + URLEncoder.encode(endpoint.getUrl(), "UTF-8"));
                 } catch (UnsupportedEncodingException e) {
                     FileLog.e(e);
                 }
@@ -44,7 +47,7 @@ public class UnifiedPushReceiver extends MessagingReceiver {
     }
 
     @Override
-    public void onMessage(Context context, byte[] message, String instance){
+    public void onMessage(PushMessage message, String instance){
         final long receiveTime = SystemClock.elapsedRealtime();
         final CountDownLatch countDownLatch = new CountDownLatch(1);
 
@@ -85,9 +88,9 @@ public class UnifiedPushReceiver extends MessagingReceiver {
     }
 
     @Override
-    public void onRegistrationFailed(Context context, String instance){
+    public void onRegistrationFailed(FailedReason reason, String instance){
         if (BuildVars.LOGS_ENABLED) {
-            FileLog.d("Failed to get endpoint");
+            FileLog.d("Failed to get endpoint: " + reason);
         }
         SharedConfig.pushStringStatus = "__UNIFIEDPUSH_FAILED__";
         Utilities.globalQueue.postRunnable(() -> {
@@ -98,7 +101,7 @@ public class UnifiedPushReceiver extends MessagingReceiver {
     }
 
     @Override
-    public void onUnregistered(Context context, String instance){
+    public void onUnregistered(String instance){
         SharedConfig.pushStringStatus = "__UNIFIEDPUSH_FAILED__";
         Utilities.globalQueue.postRunnable(() -> {
             SharedConfig.pushStringGetTimeEnd = SystemClock.elapsedRealtime();

--- a/TMessagesProj/src/main/java/org/telegram/ui/NotificationsSettingsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/NotificationsSettingsActivity.java
@@ -35,7 +35,7 @@ import android.widget.Toast;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import org.telegram.messenger.UnifiedPushReceiver;
+import org.telegram.messenger.UnifiedPushService;
 import org.unifiedpush.android.connector.UnifiedPush;
 
 import org.telegram.messenger.AndroidUtilities;
@@ -780,7 +780,7 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
                 LinearLayout linearLayout = new LinearLayout(context);
                 linearLayout.setOrientation(LinearLayout.VERTICAL);
 
-                List<String> distributors = UnifiedPush.getDistributors(ApplicationLoader.applicationContext, new ArrayList<>());
+                List<String> distributors = UnifiedPush.getDistributors(ApplicationLoader.applicationContext);
                 CharSequence[] items = distributors.toArray(new CharSequence[distributors.size()]);
 
                 String distributor = UnifiedPush.getAckDistributor(ApplicationLoader.applicationContext);
@@ -795,10 +795,10 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
                     linearLayout.addView(cell);
                     cell.setOnClickListener(v -> {
                         UnifiedPush.saveDistributor(ApplicationLoader.applicationContext, items[index].toString());
-                        UnifiedPush.registerApp(ApplicationLoader.applicationContext,
+                        UnifiedPush.register(ApplicationLoader.applicationContext,
                                 "default",
-                                new ArrayList<String>(),
-                                "Telegram Simple Push");
+                                "Telegram Simple Push",
+                                null);
                         updateUnifiedPushDistributor = true;
                         adapter.notifyItemChanged(position);
                         dialogRef.get().dismiss();
@@ -827,10 +827,10 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
                                 value += "/";
                             }
                             SharedConfig.setUnifiedPushGateway(value);
-                            UnifiedPush.registerApp(ApplicationLoader.applicationContext,
+                            UnifiedPush.register(ApplicationLoader.applicationContext,
                                     "default",
-                                    new ArrayList<String>(),
-                                    "Telegram Simple Push");
+                                    "Telegram Simple Push",
+                                    null);
                             updateUnifiedPushGateway = true;
                             adapter.notifyItemChanged(position);
                         }).setNegativeButton(LocaleController.getString("Cancel", R.string.Cancel), null)
@@ -847,13 +847,13 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
             }
             if (position == unifiedPushDistributorRow) {
                 String txt;
-                if (UnifiedPushReceiver.getNumOfReceivedNotifications() == 0) {
+                if (UnifiedPushService.getNumOfReceivedNotifications() == 0) {
                     txt = "You never received notifications with UnifiedPush since Mercurygram was started.";
                 } else {
                     txt = String.format("The last received notification with UnifiedPush was %d seconds ago.\n" +
                                         "You received %d notifications since Mercurygram was started.",
-                                        (SystemClock.elapsedRealtime() - UnifiedPushReceiver.getLastReceivedNotification()) / 1000,
-                                        UnifiedPushReceiver.getNumOfReceivedNotifications());
+                                        (SystemClock.elapsedRealtime() - UnifiedPushService.getLastReceivedNotification()) / 1000,
+                                        UnifiedPushService.getNumOfReceivedNotifications());
                 }
                 txt += String.format("\n\nThe current UnifiedPush endpoint is: %s", SharedConfig.pushString);
                 Dialog dialog = new AlertDialog.Builder(getParentActivity())


### PR DESCRIPTION
Recent versions of the UnifiedPush spec have added the possibility for a distributor to raise the app briefly to the foreground when receiving a notification https://unifiedpush.org/developers/spec/android/#service-to-raise-to-the-foreground.
To achieve that the app exposes a [`PushService`](https://unifiedpush.org/kdoc/connector/org.unifiedpush.android.connector/-push-service/) instead of a MessageReceiver, but it's not available in the version 2.3.1 of `org.unifiedpush.android:connector`, hence the version bump.

AFAICT, [Sunup](https://f-droid.org/en/packages/org.unifiedpush.distributor.sunup/) and [NextPush](https://f-droid.org/en/packages/org.unifiedpush.distributor.nextpush/) have supported this for a while and [ntfy](https://f-droid.org/en/packages/io.heckel.ntfy/) has added support for raising to foreground  in version 1.21.1.

In my tests with the latest version of ntfy notifications work without issues (I had the background connection in forkgram disabled).