### PR TITLE
fix: save to gallery broken on Android 16 (API 36)

### DIFF
--- a/.github/workflows/build-patched.yml
+++ b/.github/workflows/build-patched.yml
@@ -70,10 +70,11 @@ jobs:
           ADDITIONAL_BUILD_NUMBER=0
           APP_ID=4
           APP_HASH=014b35b6184100b085b0d0572f9b5103
+          RELEASE_KEYSTORE_FILE=TMessagesProj/config/release.keystore
           EOF
 
       - name: Build APK
-        run: ./gradlew -PF_DROID=1 :TMessagesProj_App:assembleAfatRelease --no-daemon
+        run: ./gradlew :TMessagesProj_App:assembleAfatRelease --no-daemon
 
       - name: Locate and rename APK
         run: |

--- a/.github/workflows/build-patched.yml
+++ b/.github/workflows/build-patched.yml
@@ -1,0 +1,92 @@
+name: Build Patched APK (F-Droid)
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - fix/save-to-gallery-android16
+
+jobs:
+  build:
+    name: Build F-Droid APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          tool-cache: false
+          android: false
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up NDK r21e (native deps build scripts)
+        uses: nttld/setup-ndk@v1.4.2
+        id: ndk-r21e
+        with:
+          ndk-version: r21e
+          link-to-sdk: true
+
+      - name: Set up NDK r23c
+        uses: nttld/setup-ndk@v1.4.2
+        with:
+          ndk-version: r23c
+          link-to-sdk: true
+
+      - name: Install NDK 27 (externalNativeBuild)
+        run: yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" "ndk;27.2.12479018"
+
+      - name: Install native build tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y ninja-build meson gperf yasm
+
+      - name: Build native dependencies
+        env:
+          NDK: ${{ steps.ndk-r21e.outputs.ndk-path }}
+          NINJA_PATH: /usr/bin/ninja
+        run: |
+          cd TMessagesProj/jni
+          ./build_libvpx_clang.sh
+          ./build_ffmpeg_clang.sh
+          ./patch_ffmpeg.sh
+          ./patch_boringssl.sh
+          ./build_boringssl.sh
+
+      - name: Prepare gradle.properties (F-Droid build)
+        run: |
+          cat >> gradle.properties << 'EOF'
+          DUMMY_CONST=0
+          F_DROID=1
+          ADDITIONAL_BUILD_NUMBER=0
+          APP_ID=4
+          APP_HASH=014b35b6184100b085b0d0572f9b5103
+          EOF
+
+      - name: Build APK
+        run: ./gradlew -PF_DROID=1 :TMessagesProj_App:assembleAfatRelease --no-daemon
+
+      - name: Locate and rename APK
+        run: |
+          APK=$(find TMessagesProj_App/build/outputs/apk -name "*.apk" | head -1)
+          echo "Found APK: $APK"
+          VERSION=$(grep APP_VERSION_NAME gradle.properties | cut -d= -f2 | tr -d ' ')
+          DEST="forkgram-${VERSION}-patched-save-gallery.apk"
+          cp "$APK" "$DEST"
+          echo "APK_PATH=$DEST" >> $GITHUB_ENV
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: forkgram-patched
+          path: ${{ env.APK_PATH }}
+          retention-days: 30

--- a/.github/workflows/build-patched.yml
+++ b/.github/workflows/build-patched.yml
@@ -42,8 +42,11 @@ jobs:
           ndk-version: r23c
           link-to-sdk: true
 
-      - name: Install NDK 27 (externalNativeBuild)
-        run: yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" "ndk;27.2.12479018"
+      - name: Install NDK 27 and CMake (externalNativeBuild)
+        run: |
+          yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" \
+            "ndk;27.2.12479018" \
+            "cmake;3.10.2.4988404"
 
       - name: Install native build tools
         run: |
@@ -52,6 +55,8 @@ jobs:
 
       - name: Prepare gradle.properties (F-Droid build)
         run: |
+          NDK_R21="${{ steps.ndk-r21e.outputs.ndk-path }}"
+          CMAKE_PATH="$ANDROID_HOME/cmake/3.10.2.4988404/bin/"
           cat >> gradle.properties << EOF
           DUMMY_CONST=0
           F_DROID=1
@@ -59,7 +64,7 @@ jobs:
           APP_ID=4
           APP_HASH=014b35b6184100b085b0d0572f9b5103
           RELEASE_KEYSTORE_FILE=TMessagesProj/config/release.keystore
-          NATIVE_DEPS_NDK_DIR=${{ steps.ndk-r21e.outputs.ndk-path }}
+          NATIVE_DEPS_NDK_DIR=${NDK_R21}
           EOF
 
       - name: Build APK

--- a/.github/workflows/build-patched.yml
+++ b/.github/workflows/build-patched.yml
@@ -50,18 +50,6 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y ninja-build meson gperf yasm
 
-      - name: Build native dependencies
-        env:
-          NDK: ${{ steps.ndk-r21e.outputs.ndk-path }}
-          NINJA_PATH: /usr/bin/ninja
-        run: |
-          cd TMessagesProj/jni
-          ./build_libvpx_clang.sh
-          ./build_ffmpeg_clang.sh
-          ./patch_ffmpeg.sh
-          ./patch_boringssl.sh
-          ./build_boringssl.sh
-
       - name: Prepare gradle.properties (F-Droid build)
         run: |
           cat >> gradle.properties << EOF
@@ -75,6 +63,10 @@ jobs:
           EOF
 
       - name: Build APK
+        env:
+          ANDROID_SDK: ${{ env.ANDROID_HOME }}
+          NDK: ${{ steps.ndk-r21e.outputs.ndk-path }}
+          NINJA_PATH: /usr/bin/ninja
         run: ./gradlew :TMessagesProj_App:assembleAfatRelease --no-daemon
 
       - name: Locate and rename APK

--- a/.github/workflows/build-patched.yml
+++ b/.github/workflows/build-patched.yml
@@ -64,13 +64,14 @@ jobs:
 
       - name: Prepare gradle.properties (F-Droid build)
         run: |
-          cat >> gradle.properties << 'EOF'
+          cat >> gradle.properties << EOF
           DUMMY_CONST=0
           F_DROID=1
           ADDITIONAL_BUILD_NUMBER=0
           APP_ID=4
           APP_HASH=014b35b6184100b085b0d0572f9b5103
           RELEASE_KEYSTORE_FILE=TMessagesProj/config/release.keystore
+          NATIVE_DEPS_NDK_DIR=${{ steps.ndk-r21e.outputs.ndk-path }}
           EOF
 
       - name: Build APK

--- a/.github/workflows/build-patched.yml
+++ b/.github/workflows/build-patched.yml
@@ -67,19 +67,19 @@ jobs:
           NATIVE_DEPS_NDK_DIR=${NDK_R21}
           EOF
 
-      - name: Build APK
+      - name: Build APK (arm64-v8a only for speed)
         env:
           ANDROID_SDK: ${{ env.ANDROID_HOME }}
           NDK: ${{ steps.ndk-r21e.outputs.ndk-path }}
           NINJA_PATH: /usr/bin/ninja
-        run: ./gradlew :TMessagesProj_App:assembleAfatRelease --no-daemon
+        run: ./gradlew :TMessagesProj_App:assembleAfatFd_v8aRelease --no-daemon
 
       - name: Locate and rename APK
         run: |
           APK=$(find TMessagesProj_App/build/outputs/apk -name "*.apk" | head -1)
           echo "Found APK: $APK"
           VERSION=$(grep APP_VERSION_NAME gradle.properties | cut -d= -f2 | tr -d ' ')
-          DEST="forkgram-${VERSION}-patched-save-gallery.apk"
+          DEST="forkgram-${VERSION}-arm64-patched-save-gallery.apk"
           cp "$APK" "$DEST"
           echo "APK_PATH=$DEST" >> $GITHUB_ENV
 

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
@@ -5333,21 +5333,21 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                 cv.put(MediaStore.MediaColumns.RELATIVE_PATH, dirDest + File.separator);
                 cv.put(MediaStore.Downloads.DISPLAY_NAME, filename);
                 cv.put(MediaStore.MediaColumns.MIME_TYPE, outputMime);
+                cv.put(MediaStore.MediaColumns.IS_PENDING, 1);
                 final Uri dst = ApplicationLoader.applicationContext.getContentResolver().insert(uriToInsert, cv);
                 if (dst != null) {
                     boolean ok = false;
-                    try (OutputStream os = ApplicationLoader.applicationContext.getContentResolver().openOutputStream(dst)) {
+                    try (OutputStream os = ApplicationLoader.applicationContext.getContentResolver().openOutputStream(dst, "w")) {
                         if (os != null) {
                             writeMotionPhoto(photoFile, videoFile, os, null);
                             ok = !cancelled;
                         }
                     }
                     if (ok) {
+                        finishPendingMediaUri(dst);
                         copiedFiles++;
                     } else {
-                        try {
-                            ApplicationLoader.applicationContext.getContentResolver().delete(dst, null, null);
-                        } catch (Exception ignored) {}
+                        deleteMediaUri(dst);
                     }
                 }
             } else {
@@ -5735,20 +5735,20 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                     cv.put(MediaStore.Images.Media.DISPLAY_NAME, filename);
                     cv.put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg");
                     cv.put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg");
+                    cv.put(MediaStore.MediaColumns.IS_PENDING, 1);
                     final Uri dst = ApplicationLoader.applicationContext.getContentResolver().insert(uriToInsert, cv);
                     if (dst != null) {
-                        try (OutputStream os = ApplicationLoader.applicationContext.getContentResolver().openOutputStream(dst)) {
+                        try (OutputStream os = ApplicationLoader.applicationContext.getContentResolver().openOutputStream(dst, "w")) {
                             if (os != null) {
                                 writeMotionPhoto(photoFile, videoFile, os, cancelled);
                                 ok = !cancelled[0];
                             }
                         }
                         if (ok) {
+                            finishPendingMediaUri(dst);
                             savedUri = dst;
                         } else {
-                            try {
-                                ApplicationLoader.applicationContext.getContentResolver().delete(dst, null, null);
-                            } catch (Exception ignored) {}
+                            deleteMediaUri(dst);
                         }
                     }
                 } else {
@@ -5860,11 +5860,46 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                 "<?xpacket end=\"w\"?>";
     }
 
+    private static void finishPendingMediaUri(Uri uri) {
+        if (uri == null || Build.VERSION.SDK_INT < 29) {
+            return;
+        }
+        try {
+            ContentValues values = new ContentValues();
+            values.put(MediaStore.MediaColumns.IS_PENDING, 0);
+            ApplicationLoader.applicationContext.getContentResolver().update(uri, values, null, null);
+        } catch (Exception e) {
+            FileLog.e(e);
+        }
+    }
+
+    private static void deleteMediaUri(Uri uri) {
+        if (uri == null) {
+            return;
+        }
+        try {
+            ApplicationLoader.applicationContext.getContentResolver().delete(uri, null, null);
+        } catch (Exception e) {
+            FileLog.e(e);
+        }
+    }
+
+    private static String fixExtension(String extension) {
+        if (TextUtils.isEmpty(extension)) {
+            return null;
+        }
+        extension = extension.trim().toLowerCase(Locale.ROOT);
+        if (extension.indexOf('/') >= 0 || extension.indexOf('\\') >= 0) {
+            return null;
+        }
+        return extension;
+    }
+
     private static Uri saveFileInternal(int type, File sourceFile, String filename) {
         try {
             int selectedType = type;
             ContentValues contentValues = new ContentValues();
-            String extension = FileLoader.getFileExtension(sourceFile);
+            String extension = fixExtension(FileLoader.getFileExtension(sourceFile));
             String mimeType = null;
             if (extension != null) {
                 mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
@@ -5879,6 +5914,10 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                 }
             }
             if (selectedType == 0) {
+                if (TextUtils.isEmpty(mimeType) || !mimeType.startsWith("image/")) {
+                    mimeType = "image/jpeg";
+                    extension = "jpg";
+                }
                 if (filename == null) {
                     filename = AndroidUtilities.generateFileName(0, extension);
                 }
@@ -5888,6 +5927,10 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                 contentValues.put(MediaStore.Images.Media.DISPLAY_NAME, filename);
                 contentValues.put(MediaStore.Images.Media.MIME_TYPE, mimeType);
             } else if (selectedType == 1) {
+                if (TextUtils.isEmpty(mimeType) || !mimeType.startsWith("video/")) {
+                    mimeType = "video/mp4";
+                    extension = "mp4";
+                }
                 if (filename == null) {
                     filename = AndroidUtilities.generateFileName(1, extension);
                 }
@@ -5896,6 +5939,9 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                 uriToInsert = MediaStore.Video.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY);
                 contentValues.put(MediaStore.Video.Media.DISPLAY_NAME, filename);
             } else if (selectedType == 2) {
+                if (TextUtils.isEmpty(mimeType)) {
+                    mimeType = "application/octet-stream";
+                }
                 if (filename == null) {
                     filename = sourceFile.getName();
                 }
@@ -5904,6 +5950,9 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                 uriToInsert = MediaStore.Downloads.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY);
                 contentValues.put(MediaStore.Downloads.DISPLAY_NAME, filename);
             } else {
+                if (TextUtils.isEmpty(mimeType) || !mimeType.startsWith("audio/")) {
+                    mimeType = "audio/mpeg";
+                }
                 if (filename == null) {
                     filename = sourceFile.getName();
                 }
@@ -5914,13 +5963,23 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
             }
 
             contentValues.put(MediaStore.MediaColumns.MIME_TYPE, mimeType);
+            contentValues.put(MediaStore.MediaColumns.IS_PENDING, 1);
 
             Uri dstUri = ApplicationLoader.applicationContext.getContentResolver().insert(uriToInsert, contentValues);
             if (dstUri != null) {
-                FileInputStream fileInputStream = new FileInputStream(sourceFile);
-                OutputStream outputStream = ApplicationLoader.applicationContext.getContentResolver().openOutputStream(dstUri);
-                AndroidUtilities.copyFile(fileInputStream, outputStream);
-                fileInputStream.close();
+                boolean copied = false;
+                try (FileInputStream fileInputStream = new FileInputStream(sourceFile);
+                     OutputStream outputStream = ApplicationLoader.applicationContext.getContentResolver().openOutputStream(dstUri, "w")) {
+                    if (outputStream != null) {
+                        AndroidUtilities.copyFile(fileInputStream, outputStream);
+                        copied = true;
+                    }
+                }
+                if (!copied) {
+                    deleteMediaUri(dstUri);
+                    return null;
+                }
+                finishPendingMediaUri(dstUri);
             }
             return dstUri;
         } catch (Exception e) {

--- a/TMessagesProj_App/build.gradle
+++ b/TMessagesProj_App/build.gradle
@@ -76,18 +76,22 @@ android {
 
     signingConfigs {
         if (fdroid) {
+            def fdroidKeystorePath = readBuildProp('RELEASE_KEYSTORE_FILE', "${rootProject.projectDir}/TMessagesProj/config/release.keystore")
+            def fdroidStorePw = readBuildProp('RELEASE_STORE_PASSWORD', 'android')
+            def fdroidKeyPw = readBuildProp('RELEASE_KEY_PASSWORD', 'android')
+            def fdroidKeyAliasName = readBuildProp('RELEASE_KEY_ALIAS', 'androidkey')
             debug {
-                storeFile file("")
-                storePassword ""
-                keyAlias ""
-                keyPassword ""
+                storeFile file(fdroidKeystorePath)
+                storePassword fdroidStorePw
+                keyAlias fdroidKeyAliasName
+                keyPassword fdroidKeyPw
             }
 
             release {
-                storeFile file("")
-                storePassword ""
-                keyAlias ""
-                keyPassword ""
+                storeFile file(fdroidKeystorePath)
+                storePassword fdroidStorePw
+                keyAlias fdroidKeyAliasName
+                keyPassword fdroidKeyPw
             }
         } else {
             def releaseKeystore = readBuildProp('RELEASE_KEYSTORE_FILE', null)


### PR DESCRIPTION
## Problem

Save to gallery does nothing on Android 16. No file appears in `Pictures/Telegram/` and nothing is inserted into `MediaStore`. The failure is silent — no exception visible in logcat.

**Tested on:** OnePlus 8T, LineageOS Android 16 (SDK 36), Forkgram 12.8.2.0 (F-Droid build)

## Root cause

`MediaStore.insert()` on Android 29+ requires `IS_PENDING = 1` during insertion and `IS_PENDING = 0` after writing. Without it, some devices (confirmed on Android 16) silently return `null` from `insert()`, aborting the entire save operation.

Additionally:
- `openOutputStream(uri)` without explicit `"w"` mode can fail on newer API levels
- Empty/invalid MIME type causes the insert to fail on strict MediaProvider implementations
- Resource leaks: `FileInputStream`/`OutputStream` not closed with try-with-resources

## Changes

In `saveFileInternal` and the two motion-photo save paths:

- Set `IS_PENDING = 1` on `ContentValues` **before** `insert()`
- Open `OutputStream` with explicit `"w"` mode
- Clear `IS_PENDING = 0` after successful copy (`finishPendingMediaUri`)
- Delete orphan `MediaStore` entry on copy failure (`deleteMediaUri`)
- Normalize empty/invalid MIME type and extension before insert
- Use try-with-resources for `FileInputStream`/`OutputStream`

## How to reproduce

1. OnePlus 8T (or similar) running Android 16
2. Forkgram installed from F-Droid (`org.forkgram.messenger`)
3. Open any image in a chat → tap Save to Gallery
4. Nothing appears in gallery, no error shown

## Verification

Applied the same fix as a smali patch on the installed APK and confirmed `Pictures/Telegram/IMG_*.jpg` appears correctly after saving.