### PR TITLE
fix: save to gallery broken on Android 16 (API 36)

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
@@ -5333,21 +5333,21 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                 cv.put(MediaStore.MediaColumns.RELATIVE_PATH, dirDest + File.separator);
                 cv.put(MediaStore.Downloads.DISPLAY_NAME, filename);
                 cv.put(MediaStore.MediaColumns.MIME_TYPE, outputMime);
+                cv.put(MediaStore.MediaColumns.IS_PENDING, 1);
                 final Uri dst = ApplicationLoader.applicationContext.getContentResolver().insert(uriToInsert, cv);
                 if (dst != null) {
                     boolean ok = false;
-                    try (OutputStream os = ApplicationLoader.applicationContext.getContentResolver().openOutputStream(dst)) {
+                    try (OutputStream os = ApplicationLoader.applicationContext.getContentResolver().openOutputStream(dst, "w")) {
                         if (os != null) {
                             writeMotionPhoto(photoFile, videoFile, os, null);
                             ok = !cancelled;
                         }
                     }
                     if (ok) {
+                        finishPendingMediaUri(dst);
                         copiedFiles++;
                     } else {
-                        try {
-                            ApplicationLoader.applicationContext.getContentResolver().delete(dst, null, null);
-                        } catch (Exception ignored) {}
+                        deleteMediaUri(dst);
                     }
                 }
             } else {
@@ -5735,20 +5735,20 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                     cv.put(MediaStore.Images.Media.DISPLAY_NAME, filename);
                     cv.put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg");
                     cv.put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg");
+                    cv.put(MediaStore.MediaColumns.IS_PENDING, 1);
                     final Uri dst = ApplicationLoader.applicationContext.getContentResolver().insert(uriToInsert, cv);
                     if (dst != null) {
-                        try (OutputStream os = ApplicationLoader.applicationContext.getContentResolver().openOutputStream(dst)) {
+                        try (OutputStream os = ApplicationLoader.applicationContext.getContentResolver().openOutputStream(dst, "w")) {
                             if (os != null) {
                                 writeMotionPhoto(photoFile, videoFile, os, cancelled);
                                 ok = !cancelled[0];
                             }
                         }
                         if (ok) {
+                            finishPendingMediaUri(dst);
                             savedUri = dst;
                         } else {
-                            try {
-                                ApplicationLoader.applicationContext.getContentResolver().delete(dst, null, null);
-                            } catch (Exception ignored) {}
+                            deleteMediaUri(dst);
                         }
                     }
                 } else {
@@ -5860,11 +5860,46 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                 "<?xpacket end=\"w\"?>";
     }
 
+    private static void finishPendingMediaUri(Uri uri) {
+        if (uri == null || Build.VERSION.SDK_INT < 29) {
+            return;
+        }
+        try {
+            ContentValues values = new ContentValues();
+            values.put(MediaStore.MediaColumns.IS_PENDING, 0);
+            ApplicationLoader.applicationContext.getContentResolver().update(uri, values, null, null);
+        } catch (Exception e) {
+            FileLog.e(e);
+        }
+    }
+
+    private static void deleteMediaUri(Uri uri) {
+        if (uri == null) {
+            return;
+        }
+        try {
+            ApplicationLoader.applicationContext.getContentResolver().delete(uri, null, null);
+        } catch (Exception e) {
+            FileLog.e(e);
+        }
+    }
+
+    private static String fixExtension(String extension) {
+        if (TextUtils.isEmpty(extension)) {
+            return null;
+        }
+        extension = extension.trim().toLowerCase(Locale.ROOT);
+        if (extension.indexOf('/') >= 0 || extension.indexOf('\\') >= 0) {
+            return null;
+        }
+        return extension;
+    }
+
     private static Uri saveFileInternal(int type, File sourceFile, String filename) {
         try {
             int selectedType = type;
             ContentValues contentValues = new ContentValues();
-            String extension = FileLoader.getFileExtension(sourceFile);
+            String extension = fixExtension(FileLoader.getFileExtension(sourceFile));
             String mimeType = null;
             if (extension != null) {
                 mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
@@ -5879,6 +5914,10 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                 }
             }
             if (selectedType == 0) {
+                if (TextUtils.isEmpty(mimeType) || !mimeType.startsWith("image/")) {
+                    mimeType = "image/jpeg";
+                    extension = "jpg";
+                }
                 if (filename == null) {
                     filename = AndroidUtilities.generateFileName(0, extension);
                 }
@@ -5888,6 +5927,10 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                 contentValues.put(MediaStore.Images.Media.DISPLAY_NAME, filename);
                 contentValues.put(MediaStore.Images.Media.MIME_TYPE, mimeType);
             } else if (selectedType == 1) {
+                if (TextUtils.isEmpty(mimeType) || !mimeType.startsWith("video/")) {
+                    mimeType = "video/mp4";
+                    extension = "mp4";
+                }
                 if (filename == null) {
                     filename = AndroidUtilities.generateFileName(1, extension);
                 }
@@ -5896,6 +5939,9 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                 uriToInsert = MediaStore.Video.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY);
                 contentValues.put(MediaStore.Video.Media.DISPLAY_NAME, filename);
             } else if (selectedType == 2) {
+                if (TextUtils.isEmpty(mimeType)) {
+                    mimeType = "application/octet-stream";
+                }
                 if (filename == null) {
                     filename = sourceFile.getName();
                 }
@@ -5904,6 +5950,9 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                 uriToInsert = MediaStore.Downloads.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY);
                 contentValues.put(MediaStore.Downloads.DISPLAY_NAME, filename);
             } else {
+                if (TextUtils.isEmpty(mimeType) || !mimeType.startsWith("audio/")) {
+                    mimeType = "audio/mpeg";
+                }
                 if (filename == null) {
                     filename = sourceFile.getName();
                 }
@@ -5914,13 +5963,23 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
             }
 
             contentValues.put(MediaStore.MediaColumns.MIME_TYPE, mimeType);
+            contentValues.put(MediaStore.MediaColumns.IS_PENDING, 1);
 
             Uri dstUri = ApplicationLoader.applicationContext.getContentResolver().insert(uriToInsert, contentValues);
             if (dstUri != null) {
-                FileInputStream fileInputStream = new FileInputStream(sourceFile);
-                OutputStream outputStream = ApplicationLoader.applicationContext.getContentResolver().openOutputStream(dstUri);
-                AndroidUtilities.copyFile(fileInputStream, outputStream);
-                fileInputStream.close();
+                boolean copied = false;
+                try (FileInputStream fileInputStream = new FileInputStream(sourceFile);
+                     OutputStream outputStream = ApplicationLoader.applicationContext.getContentResolver().openOutputStream(dstUri, "w")) {
+                    if (outputStream != null) {
+                        AndroidUtilities.copyFile(fileInputStream, outputStream);
+                        copied = true;
+                    }
+                }
+                if (!copied) {
+                    deleteMediaUri(dstUri);
+                    return null;
+                }
+                finishPendingMediaUri(dstUri);
             }
             return dstUri;
         } catch (Exception e) {


### PR DESCRIPTION
## Problem

Save to gallery does nothing on Android 16. No file appears in `Pictures/Telegram/` and nothing is inserted into `MediaStore`. The failure is silent — no exception visible in logcat.

**Tested on:** OnePlus 8T, LineageOS Android 16 (SDK 36), Forkgram 12.8.2.0 (F-Droid build)

## Root cause

`MediaStore.insert()` on Android 29+ requires `IS_PENDING = 1` during insertion and `IS_PENDING = 0` after writing. Without it, some devices (confirmed on Android 16) silently return `null` from `insert()`, aborting the entire save operation.

Additionally:
- `openOutputStream(uri)` without explicit `"w"` mode can fail on newer API levels
- Empty/invalid MIME type causes the insert to fail on strict MediaProvider implementations
- Resource leaks: `FileInputStream`/`OutputStream` not closed with try-with-resources

## Changes

In `saveFileInternal` and the two motion-photo save paths:

- Set `IS_PENDING = 1` on `ContentValues` **before** `insert()`
- Open `OutputStream` with explicit `"w"` mode
- Clear `IS_PENDING = 0` after successful copy (`finishPendingMediaUri`)
- Delete orphan `MediaStore` entry on copy failure (`deleteMediaUri`)
- Normalize empty/invalid MIME type and extension before insert
- Use try-with-resources for `FileInputStream`/`OutputStream`

## Verification

Tested by applying the equivalent patch as a smali modification on the installed APK. `Pictures/Telegram/IMG_*.jpg` appears correctly after saving.